### PR TITLE
Add background merge jobs with progress tracking

### DIFF
--- a/app/api/routes/merge.py
+++ b/app/api/routes/merge.py
@@ -1,8 +1,12 @@
+import asyncio
+import io
 import json
-from typing import List, Optional
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from app.dependencies.security import ApiKeyDependency
 from app.services.pdf_merger import PdfMergerService
@@ -10,14 +14,72 @@ from app.services.pdf_merger import PdfMergerService
 router = APIRouter(tags=["merge"])
 
 
-@router.post("/merge", response_class=StreamingResponse, dependencies=[ApiKeyDependency])
+@dataclass
+class JobState:
+    job_id: str
+    output_name: str
+    status: str = "queued"
+    total_pages: int = 0
+    processed_pages: int = 0
+    percent: float = 0.0
+    error: Optional[str] = None
+    result: Optional[bytes] = None
+    listeners: set[asyncio.Queue[str]] = field(default_factory=set)
+
+    def snapshot(self) -> Dict[str, object]:
+        return {
+            "job_id": self.job_id,
+            "status": self.status,
+            "total_pages": self.total_pages,
+            "processed_pages": self.processed_pages,
+            "percent": self.percent,
+            "error": self.error,
+            "has_result": self.result is not None,
+            "output_name": self.output_name,
+        }
+
+    def register_listener(self) -> asyncio.Queue[str]:
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1)
+        self.listeners.add(queue)
+        return queue
+
+    def unregister_listener(self, queue: asyncio.Queue[str]) -> None:
+        self.listeners.discard(queue)
+
+
+jobs: Dict[str, JobState] = {}
+
+
+async def _broadcast(job: JobState) -> None:
+    if not job.listeners:
+        return
+    payload = json.dumps(job.snapshot())
+    for queue in list(job.listeners):
+        try:
+            queue.put_nowait(payload)
+        except asyncio.QueueFull:  # pragma: no cover - defensive
+            try:
+                _ = queue.get_nowait()
+            except asyncio.QueueEmpty:  # pragma: no cover - defensive
+                pass
+            queue.put_nowait(payload)
+
+
+def _get_job(job_id: str) -> JobState:
+    job = jobs.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@router.post("/merge", dependencies=[ApiKeyDependency])
 async def merge_pdf(
     files: List[UploadFile] = File(..., description="Upload PDF files in desired order."),
     ranges: Optional[str] = Form(
         None, description='JSON list of page ranges per file, e.g. ["1-3,5",""]'
     ),
     output_name: Optional[str] = Form("merged.pdf"),
-) -> StreamingResponse:
+) -> JSONResponse:
     if not files:
         raise HTTPException(status_code=400, detail="No files uploaded.")
 
@@ -38,6 +100,91 @@ async def merge_pdf(
     while len(per_file_ranges) < len(files):
         per_file_ranges.append("")
 
-    merger = PdfMergerService()
-    await merger.append_files(files, per_file_ranges)
-    return merger.export(output_name)
+    finalized_name = PdfMergerService._finalize_name(output_name)
+    job_id = uuid.uuid4().hex
+    job = JobState(job_id=job_id, output_name=finalized_name)
+    jobs[job_id] = job
+
+    async def _run_job() -> None:
+        merger = PdfMergerService()
+
+        async def progress_callback(processed: int, total: int, _filename: str | None) -> None:
+            job.total_pages = total
+            job.processed_pages = processed
+            job.percent = round((processed / total * 100) if total else 0.0, 2)
+            await _broadcast(job)
+
+        try:
+            job.status = "running"
+            await _broadcast(job)
+            await merger.append_files(files, per_file_ranges, progress_callback)
+            job.result = merger.to_bytes()
+            job.status = "completed"
+            job.processed_pages = job.total_pages
+            job.percent = 100.0
+            await _broadcast(job)
+        except HTTPException as exc:
+            job.status = "error"
+            job.error = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+            await _broadcast(job)
+        except Exception as exc:  # pragma: no cover - defensive
+            job.status = "error"
+            job.error = str(exc)
+            await _broadcast(job)
+        finally:
+            for upload in files:
+                try:
+                    await upload.close()
+                except Exception:  # pragma: no cover - defensive
+                    pass
+
+    asyncio.create_task(_run_job())
+
+    return JSONResponse({"job_id": job_id, "output_name": finalized_name})
+
+
+@router.get("/merge/{job_id}", dependencies=[ApiKeyDependency])
+async def get_job_status(job_id: str) -> JSONResponse:
+    job = _get_job(job_id)
+    return JSONResponse(job.snapshot())
+
+
+@router.get("/merge/{job_id}/events", dependencies=[ApiKeyDependency])
+async def stream_job_status(job_id: str) -> StreamingResponse:
+    job = _get_job(job_id)
+
+    async def event_stream():
+        queue = job.register_listener()
+        try:
+            initial_payload = json.dumps(job.snapshot())
+            yield f"data: {initial_payload}\n\n"
+            if job.status in {"completed", "error"}:
+                return
+
+            while True:
+                data = await queue.get()
+                yield f"data: {data}\n\n"
+                if job.status in {"completed", "error"}:
+                    return
+        finally:
+            job.unregister_listener(queue)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+@router.get("/merge/{job_id}/result", response_class=StreamingResponse, dependencies=[ApiKeyDependency])
+async def download_job_result(job_id: str) -> StreamingResponse:
+    job = _get_job(job_id)
+    if job.status != "completed" or job.result is None:
+        raise HTTPException(status_code=404, detail="Result not ready")
+
+    buffer = io.BytesIO(job.result)
+    headers = {"Content-Disposition": f'attachment; filename="{job.output_name}"'}
+    return StreamingResponse(buffer, media_type="application/pdf", headers=headers)

--- a/app/dependencies/security.py
+++ b/app/dependencies/security.py
@@ -1,12 +1,16 @@
-from fastapi import Depends, Header, HTTPException
+from fastapi import Depends, Header, HTTPException, Query
 
 from app.core.config import settings
 
 
-async def verify_api_key(x_api_key: str | None = Header(default=None, convert_underscores=False)) -> None:
+async def verify_api_key(
+    x_api_key: str | None = Header(default=None, convert_underscores=False),
+    api_key: str | None = Query(default=None),
+) -> None:
     """Validate the optional API key header when a key is configured."""
 
-    if settings.api_key and x_api_key != settings.api_key:
+    provided = x_api_key or api_key
+    if settings.api_key and provided != settings.api_key:
         raise HTTPException(status_code=401, detail="Invalid API key")
 
 

--- a/app/services/pdf_merger.py
+++ b/app/services/pdf_merger.py
@@ -1,5 +1,5 @@
 import io
-from typing import Iterable, Optional
+from typing import Awaitable, Callable, Iterable, Optional
 
 from fastapi import HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
@@ -14,7 +14,18 @@ class PdfMergerService:
     def __init__(self) -> None:
         self.writer = PdfWriter()
 
-    async def append_files(self, files: Iterable[UploadFile], ranges: list[str]) -> None:
+    ProgressCallback = Callable[[int, int, str | None], Awaitable[None]]
+
+    async def append_files(
+        self,
+        files: Iterable[UploadFile],
+        ranges: list[str],
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> None:
+        processed_pages = 0
+        prepared: list[tuple[PdfReader, list[int], str]] = []
+
+        total_pages = 0
         for index, upload in enumerate(files):
             data = await upload.read()
             if len(data) == 0:
@@ -35,17 +46,36 @@ class PdfMergerService:
 
             wanted_ranges = ranges[index] if index < len(ranges) else ""
             indices = parse_page_ranges(wanted_ranges or "", len(pdf.pages))
+            total_pages += len(indices)
+            prepared.append((pdf, indices, upload.filename))
+
+        if progress_callback is not None:
+            await progress_callback(processed_pages, total_pages, None)
+
+        for pdf, indices, filename in prepared:
             for page_index in indices:
                 self.writer.add_page(pdf.pages[page_index])
+                processed_pages += 1
+                if progress_callback is not None:
+                    await progress_callback(processed_pages, total_pages, filename)
 
     def export(self, output_name: Optional[str]) -> StreamingResponse:
         buffer = io.BytesIO()
         self.writer.write(buffer)
         buffer.seek(0)
 
+        final_name = self._finalize_name(output_name)
+        headers = {"Content-Disposition": f'attachment; filename="{final_name}"'}
+        return StreamingResponse(buffer, media_type="application/pdf", headers=headers)
+
+    def to_bytes(self) -> bytes:
+        buffer = io.BytesIO()
+        self.writer.write(buffer)
+        return buffer.getvalue()
+
+    @staticmethod
+    def _finalize_name(output_name: Optional[str]) -> str:
         final_name = output_name or "merged.pdf"
         if not final_name.lower().endswith(".pdf"):
             final_name += ".pdf"
-
-        headers = {"Content-Disposition": f'attachment; filename="{final_name}"'}
-        return StreamingResponse(buffer, media_type="application/pdf", headers=headers)
+        return final_name


### PR DESCRIPTION
## Summary
- add progress-aware PDF merging that counts pages up front and emits callbacks per page
- queue merge requests as background jobs with SSE status streaming, polling fallback, and downloadable results
- refresh the web UI to surface job progress with a determinate/indeterminate bar and handle the new job API
- allow API keys to be supplied via query string so progress streams work with protected deployments

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dbb52393a0832e928fa546f103d3af