### PR TITLE
Load runtime configuration from root env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# Environment configuration for the FastAPI PDF Merger application.
+# Fill in secrets like PDF_MERGER_API_KEY before running the server.
+PDF_MERGER_API_KEY=
+PDF_MERGER_MAX_TOTAL_UPLOAD_MB=200
+# Leave blank to use the CPU core count or set an explicit limit.
+PDF_MERGE_MAX_PARALLEL=

--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,6 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
 .venv
 env/
 venv/

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -5,16 +5,15 @@
 ## 요청 단위 동작
 - `/merge` 엔드포인트는 `async def merge_pdf`로 선언되어 있어 비동기 요청 처리를 지원합니다.【F:app/api/routes/merge.py†L13-L38】
 - 각 요청마다 새로운 `PdfMergerService` 인스턴스를 생성하고, 업로드된 파일을 순차적으로 처리합니다.【F:app/api/routes/merge.py†L33-L38】
-- `PdfMergerService.append_files`는 업로드된 파일들을 for 루프 안에서 하나씩 `await upload.read()`로 읽어들인 다음, `pypdf`를 사용해 페이지를 합치는 동기 로직을 수행합니다.【F:app/services/pdf_merger.py†L16-L35】
-- PDF 파싱과 작성(`PdfReader`, `PdfWriter`)은 CPU 바운드이며 비동기화되어 있지 않으므로, 단일 병합 작업은 이벤트 루프에서 순차적으로 실행됩니다.【F:app/services/pdf_merger.py†L16-L39】
-
-정리하면, 하나의 병합 작업은 내부적으로 멀티쓰레드/멀티프로세스를 사용하지 않고 단일 이벤트 루프에서 순차적으로 수행됩니다.
-
+- `PdfMergerService.append_files`는 업로드된 파일을 비동기적으로 읽어 메모리에 담은 뒤, 페이지 병합 로직을 스레드 풀에서 실행합니다.【F:app/services/pdf_merger.py†L18-L66】
+- PDF 파싱과 작성(`PdfReader`, `PdfWriter`)은 CPU 바운드이지만, 별도 스레드에서 수행되기 때문에 이벤트 루프는 다음 요청을 계속 처리할 수 있습니다.【F:app/services/pdf_merger.py†L44-L66】
 ## 다중 요청 처리
-- FastAPI 애플리케이션은 ASGI 서버(Uvicorn 등) 위에서 실행되며, 서버의 이벤트 루프가 동시에 여러 요청을 스케줄링합니다. 다만 이 레포지토리에서는 멀티프로세스 워커 설정이나 백그라운드 큐를 직접 구성하지 않았습니다.
+- FastAPI 애플리케이션은 ASGI 서버(Uvicorn 등) 위에서 실행되며, 서버의 이벤트 루프가 동시에 여러 요청을 스케줄링합니다.
 - 각 요청은 독립적인 `PdfMergerService` 인스턴스를 사용하므로 공유 상태로 인한 동시성 문제는 없습니다.【F:app/api/routes/merge.py†L33-L38】
-- 그러나 개별 요청의 PDF 병합 로직은 CPU 바운드 동기 코드이기 때문에, 단일 Uvicorn 워커 환경에서는 긴 병합 작업이 이벤트 루프를 점유하여 다른 요청의 처리 지연을 유발할 수 있습니다.
+- PDF 병합 로직은 `anyio.to_thread`를 사용해 전용 스레드 풀에서 실행되며, 이벤트 루프는 I/O 작업(파일 업로드 수신 등)에 집중할 수 있습니다.【F:app/services/pdf_merger.py†L18-L69】
+- 동시에 수행 가능한 병합 스레드 수는 루트 디렉터리의 `.env` 파일에 정의된 `PDF_MERGE_MAX_PARALLEL` 값으로 제한할 수 있으며, 값이 없으면 CPU 코어 수를 기준으로 자동 설정됩니다.【F:app/core/concurrency.py†L1-L27】【F:app/services/pdf_merger.py†L60-L69】
 
 ## 운영 시 고려 사항
-- 동시에 많은 병합 작업을 처리해야 한다면 Uvicorn/Gunicorn과 같은 ASGI 서버에서 워커(프로세스) 수를 늘리거나, CPU 바운드 작업을 별도의 작업 큐/백그라운드 워커로 이동하는 것이 필요합니다.
-- 또는 `PdfMergerService` 내부 로직을 멀티스레드/프로세스 풀에 위임하여 이벤트 루프가 블로킹되지 않도록 개선할 수 있습니다.
+- 스레드 풀에서 CPU 바운드 병합 작업을 실행하므로 단일 워커 환경에서도 다른 요청에 대한 응답 지연이 완화됩니다.【F:app/services/pdf_merger.py†L18-L69】
+- `.env` 파일의 `PDF_MERGE_MAX_PARALLEL` 설정을 통해 스레드 풀 동시 실행 수를 조정하여, 서버 자원과 예상 동시 요청량에 맞춰 안정적으로 운영할 수 있습니다.【F:app/core/concurrency.py†L1-L27】
+- 여전히 CPU 사용량이 높은 작업이므로, 대규모 트래픽 환경에서는 Uvicorn/Gunicorn 워커 수 확장이나 별도의 작업 큐 도입을 고려하는 것이 좋습니다.

--- a/app/core/concurrency.py
+++ b/app/core/concurrency.py
@@ -1,0 +1,24 @@
+"""Utilities for managing concurrency limits for CPU-bound tasks."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from anyio import CapacityLimiter
+
+from app.core.config import settings
+
+DEFAULT_TOKEN_COUNT = max(1, os.cpu_count() or 1)
+
+
+@lru_cache(maxsize=1)
+def get_pdf_merge_limiter() -> CapacityLimiter:
+    """Return a shared limiter for CPU bound PDF merge operations."""
+
+    configured_limit = settings.pdf_merge_max_parallel
+    if configured_limit is None:
+        return CapacityLimiter(DEFAULT_TOKEN_COUNT)
+
+    return CapacityLimiter(max(1, configured_limit))
+

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,11 +1,15 @@
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
-    model_config = SettingsConfigDict(env_prefix="PDF_MERGER_", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_prefix="PDF_MERGER_",
+        env_file=".env",
+        extra="ignore",
+    )
 
     api_key: str | None = Field(
         default=None,
@@ -15,6 +19,25 @@ class Settings(BaseSettings):
         default=200,
         validation_alias=AliasChoices("MAX_MB", "PDF_MERGER_MAX_TOTAL_UPLOAD_MB"),
     )
+
+    pdf_merge_max_parallel: int | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "MERGE_MAX_PARALLEL",
+            "PDF_MERGE_MAX_PARALLEL",
+        ),
+    )
+
+    @field_validator("pdf_merge_max_parallel", mode="before")
+    @classmethod
+    def _coerce_pdf_merge_max_parallel(cls, value: object) -> int | None:
+        if value in (None, ""):
+            return None
+
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
 
 settings = Settings()

--- a/app/services/pdf_merger.py
+++ b/app/services/pdf_merger.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import io
+from dataclasses import dataclass
 from typing import Iterable, Optional
 
 from fastapi import HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
+from anyio import to_thread
 from pypdf import PdfReader, PdfWriter
 
+from app.core.concurrency import get_pdf_merge_limiter
 from app.utils.page_ranges import parse_page_ranges
 
 
@@ -14,27 +19,49 @@ class PdfMergerService:
     def __init__(self) -> None:
         self.writer = PdfWriter()
 
+    @dataclass
+    class _Payload:
+        filename: str
+        data: bytes
+        ranges: str
+
     async def append_files(self, files: Iterable[UploadFile], ranges: list[str]) -> None:
+        payloads: list[PdfMergerService._Payload] = []
         for index, upload in enumerate(files):
             data = await upload.read()
             if len(data) == 0:
                 raise HTTPException(status_code=400, detail=f"Empty file: {upload.filename}")
 
+            wanted_ranges = ranges[index] if index < len(ranges) else ""
+            payloads.append(
+                PdfMergerService._Payload(
+                    filename=upload.filename or "<unnamed>",
+                    data=data,
+                    ranges=wanted_ranges or "",
+                )
+            )
+
+        await to_thread.run_sync(
+            self._process_payloads, payloads, limiter=get_pdf_merge_limiter()
+        )
+
+    def _process_payloads(self, payloads: list[_Payload]) -> None:
+        for payload in payloads:
             try:
-                pdf = PdfReader(io.BytesIO(data))
+                pdf = PdfReader(io.BytesIO(payload.data))
             except Exception as exc:  # pragma: no cover - defensive
                 raise HTTPException(
-                    status_code=400, detail=f"Failed to read '{upload.filename}': {exc}"
+                    status_code=400,
+                    detail=f"Failed to read '{payload.filename}': {exc}",
                 ) from exc
 
             if pdf.is_encrypted:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Encrypted PDF not supported: {upload.filename}",
+                    detail=f"Encrypted PDF not supported: {payload.filename}",
                 )
 
-            wanted_ranges = ranges[index] if index < len(ranges) else ""
-            indices = parse_page_ranges(wanted_ranges or "", len(pdf.pages))
+            indices = parse_page_ranges(payload.ranges, len(pdf.pages))
             for page_index in indices:
                 self.writer.add_page(pdf.pages[page_index])
 


### PR DESCRIPTION
## Summary
- load FastAPI settings from a project root .env file and expose the PDF merge parallelism limit through Settings
- update the concurrency limiter to use the parsed setting so invalid values gracefully fall back to defaults
- document the .env-based configuration and check in a template .env for local setup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbc7684604832ebc75e9cf841d1945