### PR TITLE
Display total upload size limit

### DIFF
--- a/app/api/routes/ui.py
+++ b/app/api/routes/ui.py
@@ -35,5 +35,8 @@ async def index(request: Request) -> HTMLResponse:
             "feature_flags": {
                 "api_key_required": bool(settings.api_key),
             },
+            "limits": {
+                "total_upload_mb": settings.max_total_upload_mb,
+            },
         },
     )

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -91,6 +91,12 @@ body.app {
     pointer-events: none;
 }
 
+.upload-limit {
+    margin-top: 12px;
+    color: var(--muted);
+    font-size: .9rem;
+}
+
 .drop-icon {
     display: inline-flex;
     align-items: center;
@@ -123,6 +129,7 @@ body.app {
 }
 
 .file-row {
+    position: relative;
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(180px, 210px);
     gap: 16px;
@@ -131,6 +138,77 @@ body.app {
     background: rgba(255, 255, 255, .88);
     border: 1px solid rgba(148, 163, 184, .24);
     box-shadow: 0 10px 28px -24px rgba(15, 23, 42, .4);
+    transition: transform .15s ease, box-shadow .15s ease;
+}
+
+.file-row.dragging {
+    opacity: .65;
+    box-shadow: 0 16px 40px -28px rgba(37, 99, 235, .35);
+}
+
+.file-row.drag-over-top::before,
+.file-row.drag-over-bottom::after {
+    content: "";
+    position: absolute;
+    left: 16px;
+    right: 16px;
+    height: 4px;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, .6);
+}
+
+.file-row.drag-over-top::before {
+    top: -6px;
+}
+
+.file-row.drag-over-bottom::after {
+    bottom: -6px;
+}
+
+.file-main {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+}
+
+.file-body {
+    flex: 1;
+    min-width: 0;
+}
+
+.drag-handle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    border: 1px solid rgba(37, 99, 235, .25);
+    background: rgba(37, 99, 235, .08);
+    color: var(--accent);
+    cursor: grab;
+    transition: background .2s ease, border-color .2s ease, transform .2s ease;
+}
+
+.drag-handle:hover {
+    background: rgba(37, 99, 235, .18);
+    border-color: rgba(37, 99, 235, .35);
+    transform: translateY(-1px);
+}
+
+.drag-handle:active {
+    cursor: grabbing;
+}
+
+.drag-handle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.drag-handle span {
+    pointer-events: none;
+    font-size: 1rem;
+    letter-spacing: 2px;
 }
 
 .file-meta {
@@ -170,6 +248,7 @@ body.app {
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
+    justify-content: flex-start;
 }
 
 .icon-btn {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,7 +21,8 @@
         merge: "{{ url_for('merge_pdf') if url_for else '/merge' }}"
       },
       locale: {{ (locale | default('en')) | tojson }},
-      i18n: {{ client_translations | default({}) | tojson }}
+      i18n: {{ client_translations | default({}) | tojson }},
+      limits: {{ limits | default({}) | tojson }}
     };
   </script>
   <script src="{{ url_for('static', path='js/app.js') }}"></script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,6 +16,7 @@
       <div class="drop-icon">⬆️</div>
       <strong>{{ t.drop_instruction }}</strong>
       <p>{{ t.drop_detail }}</p>
+      <p class="upload-limit">{{ t.upload_limit_note.format(limit=limits.total_upload_mb) }}</p>
     </div>
   </label>
 

--- a/app/utils/i18n.py
+++ b/app/utils/i18n.py
@@ -21,6 +21,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
             "hero_description": "Combine multiple PDF files into a single document and control the order and page ranges with ease.",
             "drop_instruction": "Drop PDF files here or click to browse",
             "drop_detail": "Your files will stay on this device until you choose to merge them.",
+            "upload_limit_note": "You can upload up to {limit} MB in total.",
             "empty_state": "No files added yet. Add PDFs above to configure their ranges.",
             "output_label": "Output filename",
             "api_key_label": "API key",
@@ -61,8 +62,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
                 "failed_prefix": "Failed: {message}",
             },
             "aria": {
-                "move_up": "Move {name} up",
-                "move_down": "Move {name} down",
+                "drag_handle": "Drag {name} to reorder",
                 "remove": "Remove {name}",
             },
             "placeholders": {
@@ -77,6 +77,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
             "hero_description": "여러 PDF 파일을 하나의 문서로 합치고, 순서와 페이지 범위를 쉽게 제어하세요.",
             "drop_instruction": "여기에 PDF 파일을 끌어오거나 클릭하여 선택하세요",
             "drop_detail": "파일은 병합을 선택할 때까지 이 기기에만 머무릅니다.",
+            "upload_limit_note": "총 {limit}MB까지 업로드할 수 있습니다.",
             "empty_state": "아직 추가된 파일이 없습니다. 위에서 PDF를 추가해 범위를 설정하세요.",
             "output_label": "출력 파일 이름",
             "api_key_label": "API 키",
@@ -117,8 +118,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
                 "failed_prefix": "실패: {message}",
             },
             "aria": {
-                "move_up": "{name} 위로 이동",
-                "move_down": "{name} 아래로 이동",
+                "drag_handle": "{name}를 드래그하여 순서를 변경",
                 "remove": "{name} 삭제",
             },
             "placeholders": {


### PR DESCRIPTION
## Summary
- surface the maximum combined upload size in the dropzone using localized copy
- expose the configured total upload limit to templates and client-side boot payload
- add styling for the limit note so it fits the refreshed uploader layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbf01a6758832ebb7bd1b4688af774