### PR TITLE
Add reverse order control to the PDF list

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -10,6 +10,7 @@
   const mergeBtn = $('#mergeBtn');
   const apiKey = $('#apiKey');
   const clearBtn = $('#clearBtn');
+  const reverseBtn = $('#reverseBtn');
   const status = $('#status');
 
   const paperSize = $('#paperSize');
@@ -96,7 +97,8 @@
     if (files.length === 0) {
       filesDiv.classList.add('empty');
       filesDiv.innerHTML = `<p class="empty-state">${translate('messages.empty')}</p>`;
-      clearBtn.disabled = true;
+      if (clearBtn) clearBtn.disabled = true;
+      if (reverseBtn) reverseBtn.disabled = true;
       return;
     }
 
@@ -214,7 +216,8 @@
 
     filesDiv.appendChild(frag);
 
-    clearBtn.disabled = false;
+    if (clearBtn) clearBtn.disabled = false;
+    if (reverseBtn) reverseBtn.disabled = files.length <= 1;
 
     filesDiv.querySelectorAll('.file-row').forEach((row) => {
       const id = row.dataset.fileId;
@@ -384,6 +387,16 @@
   dropBox.addEventListener('dragover', (e) => { e.preventDefault(); dropBox.classList.add('is-dragover'); });
   dropBox.addEventListener('dragleave', () => { dropBox.classList.remove('is-dragover'); });
   dropBox.addEventListener('drop', (e) => { e.preventDefault(); dropBox.classList.remove('is-dragover'); addFiles(e.dataTransfer.files || []); });
+
+  if (reverseBtn) {
+    reverseBtn.addEventListener('click', () => {
+      if (files.length <= 1) return;
+      files.reverse();
+      ranges.reverse();
+      refreshList();
+      setStatus(translate('messages.reordered'), 'info');
+    });
+  }
 
   clearBtn.addEventListener('click', () => { files = []; ranges = []; refreshList(); setStatus(translate('messages.cleared'), 'info'); });
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -69,6 +69,7 @@
 
   <div class="actions">
     <button id="mergeBtn" class="primary">{{ t.merge_button }}</button>
+    <button id="reverseBtn" type="button" class="ghost" disabled>{{ t.reverse_button }}</button>
     <button id="clearBtn" type="button" class="ghost" disabled>{{ t.clear_button }}</button>
     <span class="hint">{{ t.range_hint_html | safe }}</span>
   </div>

--- a/app/utils/i18n.py
+++ b/app/utils/i18n.py
@@ -39,6 +39,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
             "scale_mode_letterbox": "Letterbox (contain)",
             "scale_mode_crop": "Crop (cover)",
             "merge_button": "Merge PDFs",
+            "reverse_button": "Reverse order",
             "clear_button": "Clear files",
             "range_hint_html": "Page range example: <code>1-3,5</code> (leave empty for entire file)",
             "range_placeholder": "Page ranges e.g. 1-3,5",
@@ -49,6 +50,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
                 "merging": "Merging…",
                 "clear": "Clear files",
                 "remove": "Remove",
+                "reverse": "Reverse order",
             },
             "messages": {
                 "empty": "No files added yet. Add PDFs above to configure their ranges.",
@@ -60,6 +62,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
                 "merged": "Merged successfully! Your download should begin automatically.",
                 "merge_failed": "Failed to merge PDFs.",
                 "failed_prefix": "Failed: {message}",
+                "reordered": "Reversed file order.",
             },
             "aria": {
                 "drag_handle": "Drag {name} to reorder",
@@ -95,6 +98,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
             "scale_mode_letterbox": "레터박스(전체 보기)",
             "scale_mode_crop": "크롭(채우기)",
             "merge_button": "PDF 병합",
+            "reverse_button": "순서 거꾸로",
             "clear_button": "파일 지우기",
             "range_hint_html": "페이지 범위 예시: <code>1-3,5</code> (비워두면 전체 페이지)",
             "range_placeholder": "페이지 범위 예: 1-3,5",
@@ -105,6 +109,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
                 "merging": "병합 중…",
                 "clear": "파일 지우기",
                 "remove": "삭제",
+                "reverse": "순서 거꾸로",
             },
             "messages": {
                 "empty": "아직 추가된 파일이 없습니다. 위에서 PDF를 추가해 범위를 설정하세요.",
@@ -116,6 +121,7 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
                 "merged": "병합이 완료되었습니다! 다운로드가 자동으로 시작됩니다.",
                 "merge_failed": "PDF 병합에 실패했습니다.",
                 "failed_prefix": "실패: {message}",
+                "reordered": "파일 순서를 거꾸로 정렬했습니다.",
             },
             "aria": {
                 "drag_handle": "{name}를 드래그하여 순서를 변경",


### PR DESCRIPTION
## Summary
- add a reverse-order button to the UI action bar and translations
- wire client-side logic to invert the current list of files and update status text

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dc8a96dbc4832e991bc186bd2127a1