### PR TITLE
Add confirmation dialogs for file removal actions

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -403,9 +403,9 @@
   };
 
   const removeFile = (i) => {
-    files.splice(i,1);
-    ranges.splice(i,1);
-    fileOptions.splice(i,1);
+    files.splice(i, 1);
+    ranges.splice(i, 1);
+    fileOptions.splice(i, 1);
     refreshList();
   };
 
@@ -414,7 +414,10 @@
     if (!btn) return;
     const i = Number(btn.dataset.index);
     if (Number.isNaN(i)) return;
-    if (btn.dataset.action === 'remove') removeFile(i);
+    if (btn.dataset.action === 'remove') {
+      if (!window.confirm(translate('messages.confirm_remove'))) return;
+      removeFile(i);
+    }
   });
 
   const reorderItems = (from, to) => {
@@ -570,6 +573,8 @@
   }
 
   clearBtn.addEventListener('click', () => {
+    if (files.length === 0) return;
+    if (!window.confirm(translate('messages.confirm_clear'))) return;
     files = [];
     ranges = [];
     fileOptions = [];

--- a/app/utils/i18n.py
+++ b/app/utils/i18n.py
@@ -71,6 +71,8 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
                 "merge_failed": "Failed to merge PDFs.",
                 "failed_prefix": "Failed: {message}",
                 "reordered": "Reversed file order.",
+                "confirm_remove": "Are you sure you want to remove this file?",
+                "confirm_clear": "Are you sure you want to clear all files?",
             },
             "aria": {
                 "drag_handle": "Drag {name} to reorder",
@@ -164,6 +166,8 @@ TRANSLATIONS: Dict[str, Dict[str, Any]] = {
                 "merge_failed": "PDF 병합에 실패했습니다!",
                 "failed_prefix": "실패: {message}",
                 "reordered": "파일 순서를 거꾸로 정렬했습니다.",
+                "confirm_remove": "이 파일을 삭제하시겠습니까?",
+                "confirm_clear": "전체 목록을 지우시겠습니까?",
             },
             "aria": {
                 "drag_handle": "{name}를 드래그하여 순서를 변경",


### PR DESCRIPTION
## Summary
- prompt users to confirm before removing individual files or clearing the list
- add localized messages for the new confirmation dialogs in English and Korean

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dce31b49dc832eb8b9936540c51880