### PR TITLE
Add dynamic footer copyright notice

### DIFF
--- a/app/api/routes/ui.py
+++ b/app/api/routes/ui.py
@@ -1,4 +1,6 @@
 # app/api/routes/ui.py
+from datetime import datetime
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
@@ -24,6 +26,7 @@ async def index(request: Request) -> HTMLResponse:
             "locale": locale,
             "t": translations["template"],
             "client_translations": translations["client"],
+            "current_year": datetime.now().year,
             # 템플릿에 내려줄 기본값/플래그
             "defaults": {
                 "output_name": "merged.pdf",

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,6 +21,9 @@
           GNU Affero General Public License v3.0 (AGPLv3)
         </a>.
       </p>
+      <p>
+        Copyright © 2025-{{ current_year }} Mugen-Houyou - All Rights Reserved.
+      </p>
     </footer>
   </div>
   <script>


### PR DESCRIPTION
## Summary
- pass the current year from the UI route to templates
- render a copyright notice in the shared footer using the server-provided year

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e84f162188832e9b5c8c391ad4d6ce